### PR TITLE
feat(pipeline_detail): add button to open job logs in browser

### DIFF
--- a/lib/screens/pipeline_detail_screen.dart
+++ b/lib/screens/pipeline_detail_screen.dart
@@ -155,6 +155,33 @@ class _PipelineDetailScreenState extends State<PipelineDetailScreen> {
     }
   }
 
+  Future<void> _openJobLogs(GitLabJob job) async {
+    try {
+      final url = Uri.parse(job.webUrl);
+      if (await canLaunchUrl(url)) {
+        await launchUrl(url, mode: LaunchMode.externalApplication);
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Could not open job logs in browser'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error opening browser: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
   Map<String, List<GitLabJob>> _groupJobsByStage(List<GitLabJob> jobs) {
     final Map<String, List<GitLabJob>> grouped = {};
     final List<String> stageOrder = []; // Track the order stages first appear
@@ -277,6 +304,16 @@ class _PipelineDetailScreenState extends State<PipelineDetailScreen> {
                       ),
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.description, size: 16),
+                    onPressed: () => _openJobLogs(job),
+                    tooltip: 'View logs',
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(
+                      minWidth: 24,
+                      minHeight: 24,
                     ),
                   ),
                 ],

--- a/lib/services/gitlab_api_service.dart
+++ b/lib/services/gitlab_api_service.dart
@@ -138,6 +138,7 @@ class GitLabApiService {
     }
   }
 
+
   Future<Map<String, dynamic>> testConnection() async {
     try {
       final uri = Uri.parse(_buildUrl('/user'));


### PR DESCRIPTION
- Allow users to view job logs directly from the pipeline detail screen
- Open job logs in an external browser using the job's web URL
- Display error messages if opening the browser fails